### PR TITLE
Change permission check from update_plugins to activate_plugins

### DIFF
--- a/EDD_SL_Plugin_Updater.php
+++ b/EDD_SL_Plugin_Updater.php
@@ -157,7 +157,7 @@ class EDD_SL_Plugin_Updater
             return;
         }
 
-        if (! current_user_can('update_plugins')) {
+        if (! current_user_can('activate_plugins')) {
             return;
         }
 
@@ -499,7 +499,7 @@ class EDD_SL_Plugin_Updater
             return;
         }
 
-        if (! current_user_can('update_plugins')) {
+        if (! current_user_can('activate_plugins')) {
             wp_die(__('You do not have permission to install plugin updates', 'easy-digital-downloads'), __('Error', 'easy-digital-downloads'), array('response' => 403));
         }
 


### PR DESCRIPTION
On web hosts that utilize [DISALLOW_FILE_MODS](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#disable-plugin-and-theme-update-and-installation), like https://wpvip.com/, the update_plugins capability check will return false and will not show that an update is available.

This changes the capability check to activate_plugins in show_update_notification() and show_changelog(). These methods are informational only, so activate_plugins is an appropriate permission level.